### PR TITLE
fix: typo on contact page

### DIFF
--- a/content/kontakt/contents.lr
+++ b/content/kontakt/contents.lr
@@ -16,7 +16,7 @@ Auf der Mailingliste werden wichtge und spannende Themen rund um Freifunk bespro
 Um also bei Freifunk Bodensee mitzumachen ist das Abonnieren der Mailingliste und vielleicht eine freundliche "Hallo, ich möchte Mitmachen"- EMail ein guter schritt!
 
 <center>
-<a href="mailto:"freifunk-bodensee@list.ffbsee.de" class="button primary">An die Mailingliste schreiben</a>
+<a href="mailto:freifunk-bodensee@list.ffbsee.de" class="button primary">An die Mailingliste schreiben</a>
 <a href="https://mailingliste.ffbsee.net/cgi-bin/mailman/listinfo/freifunk-bodensee" class="button primary">Mailingliste Abonnieren</a>
 </center><br/>
 


### PR DESCRIPTION
Otherwise it shows up as empty "mailto:" link